### PR TITLE
Prevent double submission of questions by disabling submit button during request

### DIFF
--- a/app/(unauthenticated)/sessions/[sessionId]/ask/page.tsx
+++ b/app/(unauthenticated)/sessions/[sessionId]/ask/page.tsx
@@ -18,6 +18,7 @@ const AskPage = () => {
     const [question, setQuestion] = React.useState('')
     const [submitted, setSubmitted] = React.useState(false)
     const [session, setSession] = React.useState<{ data: Session | null }>({ data: null });
+    const [loading, setLoading] = React.useState(false);
 
     // Load name from localStorage on mount
     useEffect(() => {
@@ -65,6 +66,8 @@ const AskPage = () => {
     }
 
     const handleCreate = async () => {
+        if (loading) return;
+        setLoading(true);
         const { data, error } = await supabase
             .from('questions')
             .insert([{
@@ -81,6 +84,7 @@ const AskPage = () => {
         }
         setQuestion('');
         setSubmitted(true);
+        setLoading(false);
     }
 
     return (
@@ -134,8 +138,8 @@ const AskPage = () => {
                                     required
                                 />
                                 <div className="flex gap-4">
-                                    <Button variant="default" type="submit">
-                                        Submit
+                                    <Button variant="default" type="submit" disabled={loading}>
+                                        {loading ? "Submitting..." : "Submit"}
                                     </Button>
                                 </div>
                             </form>

--- a/app/(unauthenticated)/sessions/[sessionId]/ask/page.tsx
+++ b/app/(unauthenticated)/sessions/[sessionId]/ask/page.tsx
@@ -80,6 +80,7 @@ const AskPage = () => {
 
         if (error) {
             alert(error.message);
+            setLoading(false);
             return;
         }
         setQuestion('');


### PR DESCRIPTION
This pr fixes a bug where users could submit multiple questions by clicking the submit button repeatedly before the request completes. The submit button is now disabled while the question is being submitted, preventing duplicate requests and improving user experience.

- Added a loading state to track request progress
- Disabled the submit button when loading